### PR TITLE
level-2 headings so that subheadings appear in the right pane; svg ou…

### DIFF
--- a/docs/analysis/gunrock_version_comparison_bc.md
+++ b/docs/analysis/gunrock_version_comparison_bc.md
@@ -4,7 +4,7 @@ These results are primarily for internal use. We normalize the performance of ev
 
 Tables of data for the below results, including links to JSON summaries with command lines for each experiment: [
   [BC fastest results, combining all options, Tesla V100](analysis/gunrock_version_compare_bc_Tesla_V100_all_table.md) |
-  [BC fastest results, separating all options, Tesla_V100](analysis/gunrock_version_compare_bc_Tesla_V100_undirected_table.md) |
+  [BC fastest results, separating all options, Tesla V100](analysis/gunrock_version_compare_bc_Tesla_V100_undirected_table.md) |
   [BC fastest results, combining all options, Tesla K40/80](analysis/gunrock_version_compare_bc_Tesla_K40_80_all_table.md) |
   [BC fastest results, separating all options, Tesla K40/80](analysis/gunrock_version_compare_bc_Tesla_K40_80_undirected_table.md)
 ]
@@ -12,29 +12,37 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_version_compare_bc_Tesla_V100_all = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_bc_Tesla_V100_all.json";
-  vegaEmbed('#vis_gunrock_version_compare_bc_Tesla_V100_all', spec_gunrock_version_compare_bc_Tesla_V100_all).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_bc_Tesla_V100_all', spec_gunrock_version_compare_bc_Tesla_V100_all, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_bc_Tesla_V100_undirected = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_bc_Tesla_V100_undirected.json";
-  vegaEmbed('#vis_gunrock_version_compare_bc_Tesla_V100_undirected', spec_gunrock_version_compare_bc_Tesla_V100_undirected).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_bc_Tesla_V100_undirected', spec_gunrock_version_compare_bc_Tesla_V100_undirected, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_bc_Tesla_K40_80_all = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_bc_Tesla_K40_80_all.json";
-  vegaEmbed('#vis_gunrock_version_compare_bc_Tesla_K40_80_all', spec_gunrock_version_compare_bc_Tesla_K40_80_all).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_bc_Tesla_K40_80_all', spec_gunrock_version_compare_bc_Tesla_K40_80_all, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_bc_Tesla_K40_80_undirected = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_bc_Tesla_K40_80_undirected.json";
-  vegaEmbed('#vis_gunrock_version_compare_bc_Tesla_K40_80_undirected', spec_gunrock_version_compare_bc_Tesla_K40_80_undirected).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_bc_Tesla_K40_80_undirected', spec_gunrock_version_compare_bc_Tesla_K40_80_undirected, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
 </script>
 
+## BC fastest results, combining all options, Tesla V100
 <div id="vis_gunrock_version_compare_bc_Tesla_V100_all"></div>
+
+## BC fastest results, separating all options, Tesla V100
 <div id="vis_gunrock_version_compare_bc_Tesla_V100_undirected"></div>
+
+## BC fastest results, combining all options, Tesla K40/80
 <div id="vis_gunrock_version_compare_bc_Tesla_K40_80_all"></div>
+
+## BC fastest results, separating all options, Tesla K40/80
 <div id="vis_gunrock_version_compare_bc_Tesla_K40_80_undirected"></div>

--- a/docs/analysis/gunrock_version_comparison_bfs.md
+++ b/docs/analysis/gunrock_version_comparison_bfs.md
@@ -4,7 +4,7 @@ These results are primarily for internal use. We normalize the performance of ev
 
 Tables of data for the below results, including links to JSON summaries with command lines for each experiment: [
   [BFS fastest results, combining all options, Tesla V100](analysis/gunrock_version_compare_bfs_Tesla_V100_all_table.md) |
-  [BFS fastest results, separating all options, Tesla_V100](analysis/gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred_table.md) |
+  [BFS fastest results, separating all options, Tesla V100](analysis/gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred_table.md) |
   [BFS fastest results, combining all options, Tesla K40/80](analysis/gunrock_version_compare_bfs_Tesla_K40_80_all_table.md) |
   [BFS fastest results, separating all options, Tesla K40/80](analysis/gunrock_version_compare_bfs_Tesla_K40_80_undirected_idempotence_markpred_table.md)
 ]
@@ -12,29 +12,37 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_version_compare_bfs_Tesla_V100_all = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_bfs_Tesla_V100_all.json";
-  vegaEmbed('#vis_gunrock_version_compare_bfs_Tesla_V100_all', spec_gunrock_version_compare_bfs_Tesla_V100_all).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_bfs_Tesla_V100_all', spec_gunrock_version_compare_bfs_Tesla_V100_all, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred.json";
-  vegaEmbed('#vis_gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred', spec_gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred', spec_gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_bfs_Tesla_K40_80_all = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_bfs_Tesla_K40_80_all.json";
-  vegaEmbed('#vis_gunrock_version_compare_bfs_Tesla_K40_80_all', spec_gunrock_version_compare_bfs_Tesla_K40_80_all).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_bfs_Tesla_K40_80_all', spec_gunrock_version_compare_bfs_Tesla_K40_80_all, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_bfs_Tesla_K40_80_undirected_idempotence_markpred = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_bfs_Tesla_K40_80_undirected_idempotence_markpred.json";
-  vegaEmbed('#vis_gunrock_version_compare_bfs_Tesla_K40_80_undirected_idempotence_markpred', spec_gunrock_version_compare_bfs_Tesla_K40_80_undirected_idempotence_markpred).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_bfs_Tesla_K40_80_undirected_idempotence_markpred', spec_gunrock_version_compare_bfs_Tesla_K40_80_undirected_idempotence_markpred, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
 </script>
 
+## BFS fastest results, combining all options, Tesla V100
 <div id="vis_gunrock_version_compare_bfs_Tesla_V100_all"></div>
+
+## BFS fastest results, separating all options, Tesla V100
 <div id="vis_gunrock_version_compare_bfs_Tesla_V100_undirected_idempotence_markpred"></div>
+
+## BFS fastest results, combining all options, Tesla K40/80
 <div id="vis_gunrock_version_compare_bfs_Tesla_K40_80_all"></div>
+
+## BFS fastest results, separating all options, Tesla K40/80
 <div id="vis_gunrock_version_compare_bfs_Tesla_K40_80_undirected_idempotence_markpred"></div>

--- a/docs/analysis/gunrock_version_comparison_pr.md
+++ b/docs/analysis/gunrock_version_comparison_pr.md
@@ -4,7 +4,7 @@ These results are primarily for internal use. We normalize the performance of ev
 
 Tables of data for the below results, including links to JSON summaries with command lines for each experiment: [
   [PR fastest results, combining all options, Tesla V100](analysis/gunrock_version_compare_pr_Tesla_V100_all_table.md) |
-  [PR fastest results, separating all options, Tesla_V100](analysis/gunrock_version_compare_pr_Tesla_V100_undirected_pull_table.md) |
+  [PR fastest results, separating all options, Tesla V100](analysis/gunrock_version_compare_pr_Tesla_V100_undirected_pull_table.md) |
   [PR fastest results, combining all options, Tesla K40/80](analysis/gunrock_version_compare_pr_Tesla_K40_80_all_table.md) |
   [PR fastest results, separating all options, Tesla K40/80](analysis/gunrock_version_compare_pr_Tesla_K40_80_undirected_pull_table.md)
 ]
@@ -12,29 +12,37 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_version_compare_pr_Tesla_V100_all = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_pr_Tesla_V100_all.json";
-  vegaEmbed('#vis_gunrock_version_compare_pr_Tesla_V100_all', spec_gunrock_version_compare_pr_Tesla_V100_all).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_pr_Tesla_V100_all', spec_gunrock_version_compare_pr_Tesla_V100_all, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_pr_Tesla_V100_undirected_pull = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_pr_Tesla_V100_undirected_pull.json";
-  vegaEmbed('#vis_gunrock_version_compare_pr_Tesla_V100_undirected_pull', spec_gunrock_version_compare_pr_Tesla_V100_undirected_pull).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_pr_Tesla_V100_undirected_pull', spec_gunrock_version_compare_pr_Tesla_V100_undirected_pull, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_pr_Tesla_K40_80_all = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_pr_Tesla_K40_80_all.json";
-  vegaEmbed('#vis_gunrock_version_compare_pr_Tesla_K40_80_all', spec_gunrock_version_compare_pr_Tesla_K40_80_all).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_pr_Tesla_K40_80_all', spec_gunrock_version_compare_pr_Tesla_K40_80_all, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_pr_Tesla_K40_80_undirected_pull = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_pr_Tesla_K40_80_undirected_pull.json";
-  vegaEmbed('#vis_gunrock_version_compare_pr_Tesla_K40_80_undirected_pull', spec_gunrock_version_compare_pr_Tesla_K40_80_undirected_pull).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_pr_Tesla_K40_80_undirected_pull', spec_gunrock_version_compare_pr_Tesla_K40_80_undirected_pull, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
 </script>
 
+## PR fastest results, combining all options, Tesla V100
 <div id="vis_gunrock_version_compare_pr_Tesla_V100_all"></div>
+
+## PR fastest results, separating all options, Tesla V100
 <div id="vis_gunrock_version_compare_pr_Tesla_V100_undirected_pull"></div>
+
+## PR fastest results, combining all options, Tesla K40/80
 <div id="vis_gunrock_version_compare_pr_Tesla_K40_80_all"></div>
+
+## PR fastest results, separating all options, Tesla K40/80
 <div id="vis_gunrock_version_compare_pr_Tesla_K40_80_undirected_pull"></div>

--- a/docs/analysis/gunrock_version_comparison_sssp.md
+++ b/docs/analysis/gunrock_version_comparison_sssp.md
@@ -4,7 +4,7 @@ These results are primarily for internal use. We normalize the performance of ev
 
 Tables of data for the below results, including links to JSON summaries with command lines for each experiment: [
   [SSSP fastest results, combining all options, Tesla V100](analysis/gunrock_version_compare_sssp_Tesla_V100_all_table.md) |
-  [SSSP fastest results, separating all options, Tesla_V100](analysis/gunrock_version_compare_sssp_Tesla_V100_undirected_markpred_table.md) |
+  [SSSP fastest results, separating all options, Tesla V100](analysis/gunrock_version_compare_sssp_Tesla_V100_undirected_markpred_table.md) |
   [SSSP fastest results, combining all options, Tesla K40/80](analysis/gunrock_version_compare_sssp_Tesla_K40_80_all_table.md) |
   [SSSP fastest results, separating all options, Tesla K40/80](analysis/gunrock_version_compare_sssp_Tesla_K40_80_undirected_markpred_table.md)
 ]
@@ -12,29 +12,37 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_version_compare_sssp_Tesla_V100_all = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_sssp_Tesla_V100_all.json";
-  vegaEmbed('#vis_gunrock_version_compare_sssp_Tesla_V100_all', spec_gunrock_version_compare_sssp_Tesla_V100_all).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_sssp_Tesla_V100_all', spec_gunrock_version_compare_sssp_Tesla_V100_all, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_sssp_Tesla_V100_undirected_markpred = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_sssp_Tesla_V100_undirected_markpred.json";
-  vegaEmbed('#vis_gunrock_version_compare_sssp_Tesla_V100_undirected_markpred', spec_gunrock_version_compare_sssp_Tesla_V100_undirected_markpred).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_sssp_Tesla_V100_undirected_markpred', spec_gunrock_version_compare_sssp_Tesla_V100_undirected_markpred, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_sssp_Tesla_K40_80_all = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_sssp_Tesla_K40_80_all.json";
-  vegaEmbed('#vis_gunrock_version_compare_sssp_Tesla_K40_80_all', spec_gunrock_version_compare_sssp_Tesla_K40_80_all).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_sssp_Tesla_K40_80_all', spec_gunrock_version_compare_sssp_Tesla_K40_80_all, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_version_compare_sssp_Tesla_K40_80_undirected_markpred = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_version_compare_sssp_Tesla_K40_80_undirected_markpred.json";
-  vegaEmbed('#vis_gunrock_version_compare_sssp_Tesla_K40_80_undirected_markpred', spec_gunrock_version_compare_sssp_Tesla_K40_80_undirected_markpred).then(function(result) {
+  vegaEmbed('#vis_gunrock_version_compare_sssp_Tesla_K40_80_undirected_markpred', spec_gunrock_version_compare_sssp_Tesla_K40_80_undirected_markpred, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
 </script>
 
+## SSSP fastest results, combining all options, Tesla V100
 <div id="vis_gunrock_version_compare_sssp_Tesla_V100_all"></div>
+
+## SSSP fastest results, separating all options, Tesla V100
 <div id="vis_gunrock_version_compare_sssp_Tesla_V100_undirected_markpred"></div>
+
+## SSSP fastest results, combining all options, Tesla K40/80
 <div id="vis_gunrock_version_compare_sssp_Tesla_K40_80_all"></div>
+
+## SSSP fastest results, separating all options, Tesla K40/80
 <div id="vis_gunrock_version_compare_sssp_Tesla_K40_80_undirected_markpred"></div>

--- a/docs/analysis/results_bc.md
+++ b/docs/analysis/results_bc.md
@@ -14,40 +14,52 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_primitives_bc_mteps_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bc_mteps_best.json";
-  vegaEmbed('#vis_gunrock_primitives_bc_mteps_best', spec_gunrock_primitives_bc_mteps_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bc_mteps_best', spec_gunrock_primitives_bc_mteps_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bc_avg_process_time_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bc_avg_process_time_best.json";
-  vegaEmbed('#vis_gunrock_primitives_bc_avg_process_time_best', spec_gunrock_primitives_bc_avg_process_time_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bc_avg_process_time_best', spec_gunrock_primitives_bc_avg_process_time_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bc_mteps = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bc_mteps.json";
-  vegaEmbed('#vis_gunrock_primitives_bc_mteps', spec_gunrock_primitives_bc_mteps).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bc_mteps', spec_gunrock_primitives_bc_mteps, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bc_avg_process_time = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bc_avg_process_time.json";
-  vegaEmbed('#vis_gunrock_primitives_bc_avg_process_time', spec_gunrock_primitives_bc_avg_process_time).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bc_avg_process_time', spec_gunrock_primitives_bc_avg_process_time, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bc_advance_mode = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bc_advance_mode.json";
-  vegaEmbed('#vis_gunrock_primitives_bc_advance_mode', spec_gunrock_primitives_bc_advance_mode).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bc_advance_mode', spec_gunrock_primitives_bc_advance_mode, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bc_edges = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bc_edges.json";
-  vegaEmbed('#vis_gunrock_primitives_bc_edges', spec_gunrock_primitives_bc_edges).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bc_edges', spec_gunrock_primitives_bc_edges, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 </script>
 
+## BC throughput (MTEPS), combining all options
 <div id="vis_gunrock_primitives_bc_mteps_best"></div>
+
+## BC runtime (ms), combining all options
 <div id="vis_gunrock_primitives_bc_avg_process_time_best"></div>
+
+## BC throughput (MTEPS), separating out options
 <div id="vis_gunrock_primitives_bc_mteps"></div>
+
+## BC runtime (ms), separating out options
 <div id="vis_gunrock_primitives_bc_avg_process_time"></div>
+
+## BC throughput (MTEPS) with advance mode
 <div id="vis_gunrock_primitives_bc_advance_mode"></div>
+
+## BC runtime vs. edges
 <div id="vis_gunrock_primitives_bc_edges"></div>

--- a/docs/analysis/results_bfs.md
+++ b/docs/analysis/results_bfs.md
@@ -14,40 +14,52 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_primitives_dobfs_mteps_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_dobfs_mteps_best.json";
-  vegaEmbed('#vis_gunrock_primitives_dobfs_mteps_best', spec_gunrock_primitives_dobfs_mteps_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_dobfs_mteps_best', spec_gunrock_primitives_dobfs_mteps_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_dobfs_avg_process_time_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_dobfs_avg_process_time_best.json";
-  vegaEmbed('#vis_gunrock_primitives_dobfs_avg_process_time_best', spec_gunrock_primitives_dobfs_avg_process_time_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_dobfs_avg_process_time_best', spec_gunrock_primitives_dobfs_avg_process_time_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_dobfs_mteps = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_dobfs_mteps.json";
-  vegaEmbed('#vis_gunrock_primitives_dobfs_mteps', spec_gunrock_primitives_dobfs_mteps).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_dobfs_mteps', spec_gunrock_primitives_dobfs_mteps, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_dobfs_avg_process_time = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_dobfs_avg_process_time.json";
-  vegaEmbed('#vis_gunrock_primitives_dobfs_avg_process_time', spec_gunrock_primitives_dobfs_avg_process_time).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_dobfs_avg_process_time', spec_gunrock_primitives_dobfs_avg_process_time, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_dobfs_advance_mode = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_dobfs_advance_mode.json";
-  vegaEmbed('#vis_gunrock_primitives_dobfs_advance_mode', spec_gunrock_primitives_dobfs_advance_mode).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_dobfs_advance_mode', spec_gunrock_primitives_dobfs_advance_mode, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_dobfs_edges = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_dobfs_edges.json";
-  vegaEmbed('#vis_gunrock_primitives_dobfs_edges', spec_gunrock_primitives_dobfs_edges).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_dobfs_edges', spec_gunrock_primitives_dobfs_edges, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 </script>
 
+## DOBFS throughput (MTEPS), combining all options
 <div id="vis_gunrock_primitives_dobfs_mteps_best"></div>
+
+## DOBFS runtime (ms), combining all options
 <div id="vis_gunrock_primitives_dobfs_avg_process_time_best"></div>
+
+## DOBFS throughput (MTEPS), separating out options
 <div id="vis_gunrock_primitives_dobfs_mteps"></div>
+
+## DOBFS runtime (ms), separating out options
 <div id="vis_gunrock_primitives_dobfs_avg_process_time"></div>
+
+## DOBFS throughput (MTEPS) with advance mode
 <div id="vis_gunrock_primitives_dobfs_advance_mode"></div>
+
+## DOBFS runtime vs. edges
 <div id="vis_gunrock_primitives_dobfs_edges"></div>

--- a/docs/analysis/results_edges_vertices.md
+++ b/docs/analysis/results_edges_vertices.md
@@ -10,16 +10,20 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_primitives_all_V100_edges_visited_vs_num_edges = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_all_V100_edges_visited_vs_num_edges.json";
-  vegaEmbed('#vis_gunrock_primitives_all_V100_edges_visited_vs_num_edges', spec_gunrock_primitives_all_V100_edges_visited_vs_num_edges).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_all_V100_edges_visited_vs_num_edges', spec_gunrock_primitives_all_V100_edges_visited_vs_num_edges, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_all_V100_vertices_visited_vs_num_vertices = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_all_V100_vertices_visited_vs_num_vertices.json";
-  vegaEmbed('#vis_gunrock_primitives_all_V100_vertices_visited_vs_num_vertices', spec_gunrock_primitives_all_V100_vertices_visited_vs_num_vertices).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_all_V100_vertices_visited_vs_num_vertices', spec_gunrock_primitives_all_V100_vertices_visited_vs_num_vertices, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 </script>
 
+## Edges visited vs. number of edges
 <div id="vis_gunrock_primitives_all_V100_edges_visited_vs_num_edges"></div>
+
+## Vertices visited vs. number of vertices
 <div id="vis_gunrock_primitives_all_V100_vertices_visited_vs_num_vertices"></div>

--- a/docs/analysis/results_forward_bfs.md
+++ b/docs/analysis/results_forward_bfs.md
@@ -14,40 +14,52 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_primitives_bfs_mteps_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bfs_mteps_best.json";
-  vegaEmbed('#vis_gunrock_primitives_bfs_mteps_best', spec_gunrock_primitives_bfs_mteps_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bfs_mteps_best', spec_gunrock_primitives_bfs_mteps_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bfs_avg_process_time_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bfs_avg_process_time_best.json";
-  vegaEmbed('#vis_gunrock_primitives_bfs_avg_process_time_best', spec_gunrock_primitives_bfs_avg_process_time_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bfs_avg_process_time_best', spec_gunrock_primitives_bfs_avg_process_time_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bfs_mteps = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bfs_mteps.json";
-  vegaEmbed('#vis_gunrock_primitives_bfs_mteps', spec_gunrock_primitives_bfs_mteps).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bfs_mteps', spec_gunrock_primitives_bfs_mteps, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bfs_avg_process_time = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bfs_avg_process_time.json";
-  vegaEmbed('#vis_gunrock_primitives_bfs_avg_process_time', spec_gunrock_primitives_bfs_avg_process_time).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bfs_avg_process_time', spec_gunrock_primitives_bfs_avg_process_time, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bfs_advance_mode = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bfs_advance_mode.json";
-  vegaEmbed('#vis_gunrock_primitives_bfs_advance_mode', spec_gunrock_primitives_bfs_advance_mode).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bfs_advance_mode', spec_gunrock_primitives_bfs_advance_mode, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_bfs_edges = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_bfs_edges.json";
-  vegaEmbed('#vis_gunrock_primitives_bfs_edges', spec_gunrock_primitives_bfs_edges).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_bfs_edges', spec_gunrock_primitives_bfs_edges, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 </script>
 
+## BFS throughput (MTEPS), combining all options
 <div id="vis_gunrock_primitives_bfs_mteps_best"></div>
+
+## BFS runtime (ms), combining all options
 <div id="vis_gunrock_primitives_bfs_avg_process_time_best"></div>
+
+## BFS throughput (MTEPS), separating out options
 <div id="vis_gunrock_primitives_bfs_mteps"></div>
+
+## BFS runtime (ms), separating out options
 <div id="vis_gunrock_primitives_bfs_avg_process_time"></div>
+
+## BFS throughput (MTEPS) with advance mode
 <div id="vis_gunrock_primitives_bfs_advance_mode"></div>
+
+## BFS runtime vs. edges
 <div id="vis_gunrock_primitives_bfs_edges"></div>

--- a/docs/analysis/results_pr.md
+++ b/docs/analysis/results_pr.md
@@ -21,70 +21,92 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_primitives_pr_mteps_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_mteps_best.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_mteps_best', spec_gunrock_primitives_pr_mteps_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_mteps_best', spec_gunrock_primitives_pr_mteps_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_avg_process_time_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_avg_process_time_best.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_avg_process_time_best', spec_gunrock_primitives_pr_avg_process_time_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_avg_process_time_best', spec_gunrock_primitives_pr_avg_process_time_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_mteps = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_mteps.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_mteps', spec_gunrock_primitives_pr_mteps).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_mteps', spec_gunrock_primitives_pr_mteps, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_avg_process_time = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_avg_process_time.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_avg_process_time', spec_gunrock_primitives_pr_avg_process_time).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_avg_process_time', spec_gunrock_primitives_pr_avg_process_time, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_advance_mode = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_advance_mode.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_advance_mode', spec_gunrock_primitives_pr_advance_mode).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_advance_mode', spec_gunrock_primitives_pr_advance_mode, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_edges = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_edges.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_edges', spec_gunrock_primitives_pr_edges).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_edges', spec_gunrock_primitives_pr_edges, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_push_pull_mteps = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_push_pull_mteps.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_mteps', spec_gunrock_primitives_pr_push_pull_mteps).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_mteps', spec_gunrock_primitives_pr_push_pull_mteps, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_push_pull_avg_process_time = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_push_pull_avg_process_time.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_avg_process_time', spec_gunrock_primitives_pr_push_pull_avg_process_time).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_avg_process_time', spec_gunrock_primitives_pr_push_pull_avg_process_time, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_push_pull_search_depth = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_push_pull_search_depth.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_search_depth', spec_gunrock_primitives_pr_push_pull_search_depth).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_search_depth', spec_gunrock_primitives_pr_push_pull_search_depth, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_push_pull_vertices_visited = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_push_pull_vertices_visited.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_vertices_visited', spec_gunrock_primitives_pr_push_pull_vertices_visited).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_vertices_visited', spec_gunrock_primitives_pr_push_pull_vertices_visited, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_pr_push_pull_edges_visited = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_pr_push_pull_edges_visited.json";
-  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_edges_visited', spec_gunrock_primitives_pr_push_pull_edges_visited).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_pr_push_pull_edges_visited', spec_gunrock_primitives_pr_push_pull_edges_visited, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 </script>
 
+## PR throughput (MTEPS), combining all options
 <div id="vis_gunrock_primitives_pr_mteps_best"></div>
+
+## PR runtime (ms), combining all options
 <div id="vis_gunrock_primitives_pr_avg_process_time_best"></div>
+
+## PR throughput (MTEPS), separating out options
 <div id="vis_gunrock_primitives_pr_mteps"></div>
+
+## PR runtime (ms), separating out options
 <div id="vis_gunrock_primitives_pr_avg_process_time"></div>
+
+## PR throughput (MTEPS) with advance mode
 <div id="vis_gunrock_primitives_pr_advance_mode"></div>
+
+## PR runtime vs. edges
 <div id="vis_gunrock_primitives_pr_edges"></div>
+
+## PR throughput (MTEPS) for push vs. pull, separating out options
 <div id="vis_gunrock_primitives_pr_push_pull_mteps"></div>
+
+## PR runtime (ms) for push vs. pull, separating out options
 <div id="vis_gunrock_primitives_pr_push_pull_avg_process_time"></div>
+
+## PR search depth for push vs. pull, separating out options
 <div id="vis_gunrock_primitives_pr_push_pull_search_depth"></div>
+
+## PR vertices visited for push vs. pull, separating out options
 <div id="vis_gunrock_primitives_pr_push_pull_vertices_visited"></div>
+
+## PR edges visited for push vs. pull, separating out options
 <div id="vis_gunrock_primitives_pr_push_pull_edges_visited"></div>

--- a/docs/analysis/results_search_depth.md
+++ b/docs/analysis/results_search_depth.md
@@ -8,10 +8,13 @@ Table of data for the below results, including links to JSON summaries with comm
 
 Note this plot (rendered with [Altair](https://altair-viz.github.io/)) is interactive (you can click, drag, and zoom; and mousing over a data point shows the data associated with that point).
 
-<div id="vis_gunrock_primitives_all_V100_search_depth"></div>
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_primitives_all_V100_search_depth = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_all_V100_search_depth.json";
-  vegaEmbed('#vis_gunrock_primitives_all_V100_search_depth', spec_gunrock_primitives_all_V100_search_depth).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_all_V100_search_depth', spec_gunrock_primitives_all_V100_search_depth, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 </script>
+
+## Runtime vs. search depth
+<div id="vis_gunrock_primitives_all_V100_search_depth"></div>

--- a/docs/analysis/results_sssp.md
+++ b/docs/analysis/results_sssp.md
@@ -14,40 +14,52 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_primitives_sssp_mteps_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_sssp_mteps_best.json";
-  vegaEmbed('#vis_gunrock_primitives_sssp_mteps_best', spec_gunrock_primitives_sssp_mteps_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_sssp_mteps_best', spec_gunrock_primitives_sssp_mteps_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_sssp_avg_process_time_best = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_sssp_avg_process_time_best.json";
-  vegaEmbed('#vis_gunrock_primitives_sssp_avg_process_time_best', spec_gunrock_primitives_sssp_avg_process_time_best).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_sssp_avg_process_time_best', spec_gunrock_primitives_sssp_avg_process_time_best, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_sssp_mteps = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_sssp_mteps.json";
-  vegaEmbed('#vis_gunrock_primitives_sssp_mteps', spec_gunrock_primitives_sssp_mteps).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_sssp_mteps', spec_gunrock_primitives_sssp_mteps, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_sssp_avg_process_time = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_sssp_avg_process_time.json";
-  vegaEmbed('#vis_gunrock_primitives_sssp_avg_process_time', spec_gunrock_primitives_sssp_avg_process_time).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_sssp_avg_process_time', spec_gunrock_primitives_sssp_avg_process_time, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_sssp_advance_mode = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_sssp_advance_mode.json";
-  vegaEmbed('#vis_gunrock_primitives_sssp_advance_mode', spec_gunrock_primitives_sssp_advance_mode).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_sssp_advance_mode', spec_gunrock_primitives_sssp_advance_mode, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_sssp_edges = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_sssp_edges.json";
-  vegaEmbed('#vis_gunrock_primitives_sssp_edges', spec_gunrock_primitives_sssp_edges).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_sssp_edges', spec_gunrock_primitives_sssp_edges, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 </script>
 
+## SSSP throughput (MTEPS), combining all options
 <div id="vis_gunrock_primitives_sssp_mteps_best"></div>
+
+## SSSP runtime (ms), combining all options
 <div id="vis_gunrock_primitives_sssp_avg_process_time_best"></div>
+
+## SSSP throughput (MTEPS), separating out options
 <div id="vis_gunrock_primitives_sssp_mteps"></div>
+
+## SSSP runtime (ms), separating out options
 <div id="vis_gunrock_primitives_sssp_avg_process_time"></div>
+
+## SSSP throughput (MTEPS) with advance mode
 <div id="vis_gunrock_primitives_sssp_advance_mode"></div>
+
+## SSSP runtime vs. edges
 <div id="vis_gunrock_primitives_sssp_edges"></div>

--- a/docs/analysis/results_tc.md
+++ b/docs/analysis/results_tc.md
@@ -10,17 +10,20 @@ Tables of data for the below results, including links to JSON summaries with com
 Note these plots (rendered with [Altair](https://altair-viz.github.io/)) are interactive (you can click, drag, and zoom; select items in the legend; and mousing over a data point shows the data associated with that point).
 
 <script type="text/javascript">
-
+  var svgopt = { renderer: "svg" }
   var spec_gunrock_primitives_tc_avg_process_time = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_tc_avg_process_time.json";
-  vegaEmbed('#vis_gunrock_primitives_tc_avg_process_time', spec_gunrock_primitives_tc_avg_process_time).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_tc_avg_process_time', spec_gunrock_primitives_tc_avg_process_time, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 
   var spec_gunrock_primitives_tc_edges = "https://raw.githubusercontent.com/gunrock/io/master/plots/gunrock_primitives_tc_edges.json";
-  vegaEmbed('#vis_gunrock_primitives_tc_edges', spec_gunrock_primitives_tc_edges).then(function(result) {
+  vegaEmbed('#vis_gunrock_primitives_tc_edges', spec_gunrock_primitives_tc_edges, opt=svgopt).then(function(result) {
     // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
   }).catch(console.error);
 </script>
 
+## TC runtime (ms)
 <div id="vis_gunrock_primitives_tc_avg_process_time"></div>
+
+## TC runtime vs. edges
 <div id="vis_gunrock_primitives_tc_edges"></div>


### PR DESCRIPTION
Weirdly, the results that start with `Comparing performance across Gunrock versions` (files start with `gunrock_version_comparison`) do NOT generate subheadings in the left pane, whereas the other ones do. Haven't figured that out yet.